### PR TITLE
Add category side menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
   const [selectedCategory, setSelectedCategory] = useState('Все товары');
   const [orderData, setOrderData] = useState<OrderData | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const [showCategoryMenu, setShowCategoryMenu] = useState(false);
 
   // Load user on app start
   useEffect(() => {
@@ -85,6 +86,10 @@ function App() {
   const handleBackToHome = () => {
     setCurrentView('home');
     setSelectedProduct(null);
+  };
+
+  const toggleCategoryMenu = () => {
+    setShowCategoryMenu(prev => !prev);
   };
 
   const handleCartClick = () => {
@@ -285,11 +290,29 @@ function App() {
         onSearchChange={setSearchTerm}
         onCartClick={handleCartClick}
         onLogoClick={handleBackToHome}
+        onMenuClick={toggleCategoryMenu}
         user={user}
         onUserClick={handleUserClick}
         onLogout={handleLogout}
       />
-      
+
+      {showCategoryMenu && (
+        <div className="fixed inset-0 z-40 flex">
+          <div className="bg-white w-64 p-4 shadow-lg overflow-y-auto">
+            <h2 className="text-lg font-semibold mb-4">Категории</h2>
+            <CategoryFilter
+              categories={categories}
+              selectedCategory={selectedCategory}
+              onCategoryChange={(category) => {
+                setSelectedCategory(category);
+                setShowCategoryMenu(false);
+              }}
+            />
+          </div>
+          <div className="flex-1" onClick={() => setShowCategoryMenu(false)} />
+        </div>
+      )}
+
       <main>
         {renderCurrentView()}
       </main>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ interface HeaderProps {
   onSearchChange: (term: string) => void;
   onCartClick: () => void;
   onLogoClick: () => void;
+  onMenuClick: () => void;
   user: UserType | null;
   onUserClick: () => void;
   onLogout: () => void;
@@ -19,6 +20,7 @@ export const Header: React.FC<HeaderProps> = ({
   onSearchChange,
   onCartClick,
   onLogoClick,
+  onMenuClick,
   user,
   onUserClick,
   onLogout
@@ -29,17 +31,25 @@ export const Header: React.FC<HeaderProps> = ({
     <header className="bg-white shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          {/* Logo */}
-          <div 
-            className="flex items-center cursor-pointer group"
-            onClick={onLogoClick}
-          >
-            <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-blue-800 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform">
-              <span className="text-white font-bold text-lg">БТ</span>
-            </div>
-            <div className="ml-3">
-              <h1 className="text-xl font-bold text-gray-900">БытТехника</h1>
-              <p className="text-xs text-gray-500">Магазин бытовых товаров</p>
+          {/* Left Menu and Logo */}
+          <div className="flex items-center">
+            <button
+              onClick={onMenuClick}
+              className="p-2 mr-2 text-gray-600 hover:text-blue-600 transition-colors"
+            >
+              <Menu className="h-6 w-6" />
+            </button>
+            <div
+              className="flex items-center cursor-pointer group"
+              onClick={onLogoClick}
+            >
+              <div className="w-10 h-10 bg-gradient-to-br from-blue-600 to-blue-800 rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform">
+                <span className="text-white font-bold text-lg">БТ</span>
+              </div>
+              <div className="ml-3">
+                <h1 className="text-xl font-bold text-gray-900">БытТехника</h1>
+                <p className="text-xs text-gray-500">Магазин бытовых товаров</p>
+              </div>
             </div>
           </div>
 
@@ -112,9 +122,6 @@ export const Header: React.FC<HeaderProps> = ({
               )}
             </button>
 
-            <button className="lg:hidden p-2 text-gray-600 hover:text-blue-600 transition-colors">
-              <Menu className="h-6 w-6" />
-            </button>
           </div>
         </div>
       </div>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -36,7 +36,7 @@ export const Login: React.FC<LoginProps> = ({
       } else {
         setError(result.message);
       }
-    } catch (err) {
+    } catch {
       setError('Произошла ошибка при входе');
     } finally {
       setIsLoading(false);

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -68,7 +68,7 @@ export const Register: React.FC<RegisterProps> = ({
       } else {
         setErrors({ general: result.message });
       }
-    } catch (err) {
+    } catch {
       setErrors({ general: 'Произошла ошибка при регистрации' });
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## Summary
- implement a side menu for category selection
- add menu button to `Header`
- show menu overlay in `App`
- fix lint errors and add missing newlines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684536cb0a5083208a05a261a69f9a6b